### PR TITLE
B2140 unique managed zone

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -5,7 +5,7 @@ resource "google_project_service" "dns" {
 }
 
 resource "google_dns_managed_zone" "this" {
-  name     = local.block_ref
+  name     = local.resource_name
   dns_name = local.fqdn
   labels   = local.labels
   count    = !local.is_passthrough ? 1 : 0


### PR DESCRIPTION
This PR addresses an issue where launching subdomains in preview envs produces a collision in resource naming. This will make sure the managed zone name is unique.