### PR TITLE
Deconflict `a.b.domain.com` from `b.domain.com` [proposal]

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,13 @@ variable "disable_certificate" {
   default     = false
   description = "Specify true to disable SSL certificate creation"
 }
+
+variable "skip_delegation" {
+  type        = bool
+  default     = false
+  description = <<EOF
+Enable skip_delegation to prevent creating a GCP DNS zone dedicated to this subdomain.
+This is useful when two subdomains in Nullstone collide (e.g. `a.b.domain.com` and `b.domain.com`).
+By enabling, all subsequent DNS records are stored in the root domain DNS zone `domain.com`.
+EOF
+}


### PR DESCRIPTION
This PR adds an additional variable, `skip_delegation`, that allows a user to force any DNS records to be created in the root DNS zone instead of adding the records to a delegated DNS zone for this specific subdomain. 
This is one way to avoid conflicts when creating 2 delegation DNS zones that overlap (e.g. `a.b.domain.com` and `b.domain.com`)