### PR TITLE
F/2154/flatten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ override.tf.json
 
 __backend__.tf
 
+.nullstone/active-workspace.yml

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,24 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "6.13.0"
+  version = "6.19.0"
   hashes = [
-    "h1:+2T5mGN0JeFWxrQx+WVSR+H8+oCY943zmNEVc/Cz1j4=",
-    "h1:K01g96E7e30a7ydomvB2PgH82UtXRCbzRW2qtt0yyb8=",
-    "h1:PpxlbsdUC7HBfbMHGc6A7bWNbCtAl0BnZyplFRNvU8A=",
-    "h1:YiSOZFsdpzXgRN5NB01Fzfs8mvAlTnrM85/QktOhmgw=",
-    "h1:jakE2O6gqqQHIZYnr4K7zCNqlMDO/VMgVbCPbbLT/Oc=",
-    "zh:05067a572a2fcec7ab2e613611db68ff9fdaac18869f76ca53ce308f8f4b904a",
-    "zh:1122fae676ba52d4842267ce8a9e391c262d2468c095b6ad7b0550c1bf292b05",
-    "zh:1cde30b75d4e5ecd8eabcf2f9119302611a2b757f9cd50474c21f30dba77dd60",
-    "zh:444d333a8af09d4f561a09c56eee48cd23e97fca94c427ae5e4a24745418a097",
-    "zh:471303b121adf8b9225de70127f62f3b96033a9ab6e14f9dc7fe19f6d224186d",
-    "zh:4caa73ea78c85dc4abde022d114d4d2ff770636def8f308472e3679ac5195d9a",
-    "zh:6257a064015ed1c277cfb39027b91de2b7bc6f1ce6d42058b9df3d5aa37ecb4f",
-    "zh:8a45fe7f3e4b10ba6e8c5e44fecd0c7389e6f9c8cca11d052a357fbaae615c1a",
-    "zh:8ce6902473efdf92724679c2b63905263d83dcf77bd8d9e9f45701cdc9dcc229",
-    "zh:ce8951ef5ce96d694f7fbcea6d7dd593f6102b3ac1c686e03f08316dd7923d2d",
-    "zh:ef009b465067b8d3646d0c6ca8a6ba860d4591ddc427f005cfa5d4fcac0c4fce",
+    "h1:8YKQt+0YYI/sCcGVuJNqbnwsnijspeKZFm2WyOmgdhM=",
+    "h1:Mug/ens8Xqf8uyAL249htDwsfWiDbzeJROygk7BXMkc=",
+    "h1:QMXc663+iJC+OLfCselgozaGvKcjEnas/v2IXYwGwlk=",
+    "h1:ds4JJfKneBPyU5K/pkW1jyO1xN3e4yYIDgZ0cZwOvXk=",
+    "h1:lZA6MnJgzjpDtwMCzCJLQP2Nn9zy4Ay64lynC/jF4A8=",
+    "zh:32ffeedd1131d81f290f4e4213b948c221f40d6b3b5e54b22781c2ed6e8ad3a5",
+    "zh:40b388e0356d849e6bf3f03be950f6bb7fa3e26a9a85977662f58f693a93901b",
+    "zh:5775262765dd66dae4886f3e8c85a39d4954892e352ce077e21f9310ffd6a9f4",
+    "zh:5e4626bdde902e35c97179a421fb303fa76e08ef89271275a40468d26f93a05e",
+    "zh:5fcc9482ec0b697f0d2223117f770e7eb6146837bf5d509b1ed59ae24ffd623f",
+    "zh:829e8bb61e4ac47e70138f7a381e9f0e6e51dc76d4f373fd0eb2da7d9d3d5968",
+    "zh:8baeab5b3bcafb03cb567302df6047580300b5881de9694c3fa40f4b6f6bf714",
+    "zh:a6a800d89e3dcbdcb5ba8bd87e981a1336785cdb206610581ba072828b2a83c4",
+    "zh:bf7620009f0a1b89756f2aa2a748db8bd0683947f26bb1999ba1c8c6479d1149",
+    "zh:d93b4202012672becf64473775330928c3cdf4471eb3db4502e7cca1badfbe6a",
+    "zh:dbeae2a0a11062d285964c0360c8f090cf260d163823c0f237396ce64900fb43",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.4 (Feb 07, 2025)
+* Flatten subdomain if using a wildcard certificate.
+
 # 0.3.3 (Jan 27, 2025)
 * Add a random string to the end of the managed zone name so it is always unique.
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ This module adds the current Nullstone environment into the FQDN for the resulti
 If `var.create_vanity = true`, then the environment chunk is omitted from the FQDN.
 In the above example, the FQDN becomes: `api.acme.com`.
 Typically, enabling this variable is done to create a production URL.
+
+## Wildcard Certificate
+
+If this module detects that you are using a certificate with a wildcard subdomain, it will flatten the above subdomain calculation.
+
+#### Example
+  Certificate Domain: `*.acme.com`
+  Domain:     `acme.com`
+  Env:        `dev`
+  `dns_name`: `api`
+  FQDN:       `api-dev.acme.com`

--- a/cert.tf
+++ b/cert.tf
@@ -8,6 +8,7 @@ locals {
   ext_certificate_id       = try(data.ns_connection.certificate.outputs.certificate_id, "")
   ext_certificate_map_id   = try(data.ns_connection.certificate.outputs.certificate_map_id, "")
   ext_certificate_map_name = try(data.ns_connection.certificate.outputs.certificate_map_name, "")
+  ext_certificate_domains  = try(data.ns_connection.certificate.outputs.certificate_domains, "")
 
   create_cert = !var.disable_certificate && local.ext_certificate_map_id == ""
 }
@@ -32,4 +33,5 @@ locals {
   certificate_id       = coalesce(local.ext_certificate_id, module.cert.certificate_id)
   certificate_map_id   = coalesce(local.ext_certificate_map_id, module.cert.certificate_map_id)
   certificate_map_name = coalesce(local.ext_certificate_map_name, module.cert.certificate_map_name)
+  certificate_domains  = coalesce(local.ext_certificate_domains, module.cert.certificate_domains)
 }

--- a/cert.tf
+++ b/cert.tf
@@ -8,7 +8,7 @@ locals {
   ext_certificate_id       = try(data.ns_connection.certificate.outputs.certificate_id, "")
   ext_certificate_map_id   = try(data.ns_connection.certificate.outputs.certificate_map_id, "")
   ext_certificate_map_name = try(data.ns_connection.certificate.outputs.certificate_map_name, "")
-  ext_certificate_domains  = try(data.ns_connection.certificate.outputs.certificate_domains, "")
+  ext_certificate_domains  = try(data.ns_connection.certificate.outputs.certificate_domains, [])
 
   create_cert = !var.disable_certificate && local.ext_certificate_map_id == ""
 }

--- a/subdomain.tf
+++ b/subdomain.tf
@@ -5,7 +5,15 @@ data "ns_subdomain" "this" {
 }
 
 locals {
-  fqdn           = data.ns_subdomain.this.fqdn
+  // If we detect that the certificate is a wildcard (e.g. `*.acme.com`), we need to flatten our subdomains
+  // This is because an SSL cert on `*.acme.com` will not work for `a.b.acme.com`
+  // To flatten our subdomain, we're going to replace all `.` with `-` in the `subdomain_name` (i.e. the subdomain fqdn without the domain suffix)
+  needs_flattened = anytrue([for domain in local.certificate_domains : strcontains(domain, "*")])
+  // Normally, we rely on ns_subdomain to construct the fqdn
+  // However, if we're flattening, we need to manually construct it
+  // It should look like this: replace(subdomain_name, ".", "-") + "." + domain_name + "."
+  flattened_fqdn = "${replace(data.ns_subdomain.this.subdomain_name, ".", "-")}.${data.ns_subdomain.this.domain_name}."
+  fqdn           = local.needs_flattened ? local.flattened_fqdn : data.ns_subdomain.this.fqdn
   is_passthrough = local.fqdn == local.domain_fqdn
 
   // created_zone_id refers to google_dns_managed_zone.this.name; however, we need this variable to wait on the resource to be created


### PR DESCRIPTION
When a `certificate` connection is specified and that certificate contains a wildcard (`*`), this module will "flatten" the resulting subdomain.
For example, a subdomain that would've been `a.b.acme.com` becomes `a-b.acme.com`.
This is to ensure that the wildcard certificate is capable of serving the resulting traffic.